### PR TITLE
Add --file handle

### DIFF
--- a/example/example.nomad
+++ b/example/example.nomad
@@ -15,6 +15,7 @@ job "spin-hello-world" {
 
       config {
         listen     = "${NOMAD_IP_http}:${NOMAD_PORT_http}"
+        #file       = "/home/nomad/test/spin.toml"
         bindle_id  = "spin-hello-world/1.0.0"
         bindle_url = "http://bindle.local.fermyon.link:8088/v1"
         env = {


### PR DESCRIPTION
For deployments where spin.toml (and maybe the .wasm binary) could be locally on the node. Eg. when using Terraform to start template nomad node.

